### PR TITLE
Use hash_equals() for HMAC validation, polyfill hash_equals() all the way back to PHP 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
+        "sarciszewski/php-future": "^0.4",
         "ext-mcrypt": "*"
     },
     "require-dev": {

--- a/lib/RNCryptor/Decryptor.php
+++ b/lib/RNCryptor/Decryptor.php
@@ -96,7 +96,7 @@ class Decryptor extends Cryptor {
 
 	private function _hmacIsValid($components, $password) {
 		$hmacKey = $this->_generateKey($components->headers->hmacSalt, $password);
-		return ($components->hmac == $this->_generateHmac($components, $hmacKey));
+		return \hash_equals($components->hmac, $this->_generateHmac($components, $hmacKey));
 	}
 
 }


### PR DESCRIPTION
Fixes #5