### PR TITLE
make the base64encode() optional

### DIFF
--- a/src/RNCryptor/Encryptor.php
+++ b/src/RNCryptor/Encryptor.php
@@ -83,7 +83,7 @@ class Encryptor extends Cryptor
         return $components;
     }
 
-    private function encryptFromComponents($plaintext, stdClass $components, $encKey, $hmacKey)
+    private function encryptFromComponents($plaintext, stdClass $components, $encKey, $hmacKey, $base64encode = true)
     {
         $iv = $components->headers->iv;
         if ($this->config->mode == 'ctr') {
@@ -92,14 +92,16 @@ class Encryptor extends Cryptor
             $components->ciphertext = $this->encryptInternal($encKey, $plaintext, 'cbc', $iv);
         }
 
-        return base64_encode(''
+        $data = ''
             . $components->headers->version
             . $components->headers->options
             . ($components->headers->encSalt ?? '')
             . ($components->headers->hmacSalt ?? '')
             . $components->headers->iv
             . $components->ciphertext
-            . $this->makeHmac($components, $hmacKey));
+            . $this->makeHmac($components, $hmacKey);
+
+        return $base64encode ? base64_encode($data) : $data;
     }
 
     private function makeSalt()


### PR DESCRIPTION
In order to provide better interoperability to [RNCryptor-objc](https://github.com/RNCryptor/RNCryptor-objc) the mandatory base64encode() that is return by encrypt()-method isn't a good idea here.

Leaving it optional provides the encryption in "plain binary" that can be used directly without an extra base64_decode. Also less bandwidth is necessary without base64

In this PR i made it optionally with a Default to the current versions behaviour, so there will be NO compatibility break.