### PR TITLE
PHP 7.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 before_script:
   - composer install
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,45 +1,45 @@
 {
 	"name": "rncryptor/rncryptor",
-    "type": "library",
-    "description": "PHP implementation of RNCryptor",
-    "keywords": ["encryption", "crypto", "rncryptor"],
-    "homepage": "http://rncryptor.github.io",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Rob Napier",
-            "email": "robnapier@gmail.com"
-        },
-        {
-            "name": "Guysung Kim",
-            "email": "guysung.kim@gmail.com"
-        },
-        {
-            "name": "Curtis Farnham",
-            "email": "curtisfarnham@gmail.com"
-        }
-    ],
-    "require": {
+	"type": "library",
+	"description": "PHP implementation of RNCryptor",
+	"keywords": ["encryption", "crypto", "rncryptor"],
+	"homepage": "http://rncryptor.github.io",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Rob Napier",
+			"email": "robnapier@gmail.com"
+		},
+		{
+			"name": "Guysung Kim",
+			"email": "guysung.kim@gmail.com"
+		},
+		{
+			"name": "Curtis Farnham",
+			"email": "curtisfarnham@gmail.com"
+		}
+	],
+	"require": {
 		"php": ">=7.0 <7.3",
 		"ext-openssl": "*"
 	},
-    "require-dev": {
+	"require-dev": {
 		"rncryptor/spec": "~4.0",
 		"phpunit/phpunit": "~6.0",
-        "squizlabs/php_codesniffer": "^2.8"
-    },
-    "autoload": {
-        "psr-4": {
-            "RNCryptor\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests/"
-        }
-    },
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true
-    }
+		"squizlabs/php_codesniffer": "^2.8"
+	},
+	"autoload": {
+		"psr-4": {
+			"RNCryptor\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Tests\\": "tests/"
+		}
+	},
+	"config": {
+		"preferred-install": "dist",
+		"sort-packages": true
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-		"php": ">=7.0 <7.2",
+		"php": ">=7.0 <7.3",
 		"ext-openssl": "*"
 	},
     "require-dev": {


### PR DESCRIPTION
PHP 7.2 was [just released](http://php.net/archive/2017.php) and it'd be nice if RNCryptor supported this version too. This PR adds support for just that.