### PR TITLE
add the ability to set iterations

### DIFF
--- a/examples/decrypt.php
+++ b/examples/decrypt.php
@@ -8,6 +8,8 @@ $base64Encrypted = "AgGXutvFqW9RqQuokYLjehbfM7F+8OO/2sD8g3auA+oNCQFoarRmc59qcKJv
     . 'EN7Cv";
 
 $cryptor = new \RNCryptor\RNCryptor\Decryptor;
+//uncomment the following line to set iterations
+//$cryptor->setIterations(1);
 $plaintext = $cryptor->decrypt($base64Encrypted, $password);
 
 echo "Base64 Encrypted:\n$base64Encrypted\n\n";

--- a/examples/encrypt.php
+++ b/examples/encrypt.php
@@ -6,6 +6,8 @@ $password = "myPassword";
 $plaintext = "Here is my test vector. It's not too long, but more than a block and needs padding.";
 
 $cryptor = new \RNCryptor\RNCryptor\Encryptor;
+//uncomment the following line to set iterations
+//$cryptor->setIterations(1);
 $base64Encrypted = $cryptor->encrypt($plaintext, $password);
 
 echo "Plaintext:\n$plaintext\n\n";

--- a/src/RNCryptor/Cryptor.php
+++ b/src/RNCryptor/Cryptor.php
@@ -9,6 +9,12 @@ class Cryptor
 
     protected $config;
 
+    protected $iterations = 10000;
+
+	public function setIterations($num) {
+		$this->iterations = $num;
+	}
+
     public function generateKey($salt, $password, $version = self::DEFAULT_SCHEMA_VERSION)
     {
         $this->configure($version);
@@ -84,7 +90,7 @@ class Cryptor
 
         $config->pbkdf2 = new stdClass;
         $config->pbkdf2->prf = 'sha1';
-        $config->pbkdf2->iterations = 10000;
+        $config->pbkdf2->iterations = $this->iterations;
         $config->pbkdf2->keyLength = 32;
 
         $config->hmac = new stdClass();


### PR DESCRIPTION
Our company uses RNCryptor for years,  we upgraded our backend to the latest version 7 months ago. However, we found out that it does not support "set iterations", which is supported in both Java and Swift. We need the ability to set iterations for both encrypt and decrypt to reduce the CPU resource needed for doing the computation.